### PR TITLE
Allow `__` due to frequent Ramda placeholder usage

### DIFF
--- a/frontend-config/core.js
+++ b/frontend-config/core.js
@@ -115,7 +115,7 @@ module.exports = {
     'no-new-object': 'error',
     'no-plusplus': 'error',
     'no-trailing-spaces': 'error',
-    'no-underscore-dangle': ['error', { 'allowAfterThis': true }],
+    'no-underscore-dangle': ['error', { 'allowAfterThis': true, 'allow': [ '__'] }],
     'no-unneeded-ternary': 'error',
     'no-whitespace-before-property': 'error',
     'object-curly-newline': ['error', { 'minProperties': 2, 'consistent': true }],

--- a/frontend-config/core.js
+++ b/frontend-config/core.js
@@ -115,7 +115,7 @@ module.exports = {
     'no-new-object': 'error',
     'no-plusplus': 'error',
     'no-trailing-spaces': 'error',
-    'no-underscore-dangle': ['error', { 'allowAfterThis': true, 'allow': [ '__'] }],
+    'no-underscore-dangle': ['error', { 'allowAfterThis': true, 'allow': ['__'] }],
     'no-unneeded-ternary': 'error',
     'no-whitespace-before-property': 'error',
     'object-curly-newline': ['error', { 'minProperties': 2, 'consistent': true }],


### PR DESCRIPTION
Add an exception to `no-underscore-dangle` to ignore Ramda's double underscore placeholder.